### PR TITLE
Solve the second part of Day 1

### DIFF
--- a/1/Makefile
+++ b/1/Makefile
@@ -1,13 +1,19 @@
 .PHONY: all
 all: sample
 
-accel.futil: accelgen.py
-	python3 $^ > $@
+part1.futil: accelgen.py
+	python3 $^ 1 > $@
+
+part2.futil: accelgen.py
+	python3 $^ 3 > $@
 
 %.json: %.txt
 	python3 convert.py < $^ > $@
 
-.PHONY: run
-%: accel.futil %.json
+part1-%: part1.futil %.json
+	fud e $< --to dat --through verilog -s verilog.data $*.json | \
+		jq .memories.answer[0]
+
+part2-%: part2.futil %.json
 	fud e $< --to dat --through verilog -s verilog.data $*.json | \
 		jq .memories.answer[0]

--- a/1/README.md
+++ b/1/README.md
@@ -13,16 +13,20 @@ It was very helpful to use a Python generator instead of writing the Calyx IL di
 Simple quality-of-life advantages include interleaving cells and the groups that use them.
 It was also nice to be able to define Python constants for magic numbers (various sizes and widths).
 
+To solve part 2, we need to generalize a simple `max` operation to broader "top-k" functionality.
+This was probably the most interesting part of the Calyx implementation: we use a parameterized generator that takes a `k` and produces a little component that wraps `k` registers.
+You can think of many different ways to update the top `k` values, such as keeping a sorted list; we used a simple strategy that combinationally re-identifies the minimum value each time.
+It's not clear if this is wise at all, but it is kind of fun.
+
 To run the whole thing on the sample input, through Verilator:
 
-    make sample
+    make part1-sample
 
 To run on your special input, put it in a file called `full.txt` or something and then do:
 
-    make full
+    make part1-full
 
-The current implementation earns one star.
-For the second star, we'd need to implement some "top-k" comparison, which shouldn't be too hard.
-It would be entertaining, if not all that wise, to try to do this with some parallelism.
+That's for the first star.
+To earn the second star, use `part2-sample` or similar.
 
 [day1]: https://adventofcode.com/2022/day/1

--- a/1/accelgen.py
+++ b/1/accelgen.py
@@ -205,13 +205,15 @@ def build_topk(prog: Builder, k: int):
     # Replace the minimum value. Because we only have the index of the
     # register we need, we need a bunch of conditional logic to write
     # into the correct register.
+    wdone = topk.cell("wdone", ast.Stdlib().op("wire", 1, signed=False))
     with topk.group("upd") as upd:
         for i in range(k):
             const_i = const(idx_width, i)
             regs[i].write_en = (min_idx.out == const_i) @ 1
             regs[i].write_en = (min_idx.out != const_i) @ 0
             regs[i].in_ = (min_idx.out == const_i) @ topk.this().value
-            upd.done = (min_idx.out == const_i) @ regs[i].done
+            wdone.in_ = (min_idx.out == const_i) @ regs[i].done
+    upd.done = wdone.out
 
     # The control program.
     topk.control += if_(gt.out, check, upd)

--- a/1/accelgen.py
+++ b/1/accelgen.py
@@ -1,4 +1,4 @@
-from calyx.builder import Builder, while_, if_
+from calyx.builder import Builder, while_, if_, const
 from calyx import py_ast as ast
 
 WIDTH = 32
@@ -131,7 +131,106 @@ def build():
         finish,
     ]
 
+    build_topk(prog, 3)
     return prog.program
+
+
+def build_topk(prog: Builder, k: int):
+    """Build a component that tracks the largest K values it sees.
+
+    The strategy is that we keep the current "running" top K in K
+    registers (unordered). If the new value is bigger than the smallest
+    of these registers, we drop that smallest value and put the new
+    value in its place. This strategy avoid the need to do sequential
+    comparisons, or to keep a sorted list, but it does require some
+    "reduction" logic to find the smallest value every time. This is
+    probably acceptable for small K and admits reasonable parallelism;
+    for larger K, you might want to store state about the order of the
+    current top K.
+    """
+    topk = prog.component(f"top{k}")
+
+    # You invoke the component with a new value to "push" into the set,
+    # and you get the sum of the top K values you have ever pushed in
+    # the past.
+    topk.input("value", WIDTH)
+    topk.output("total", WIDTH)
+
+    # We keep track of the top K values in K registers.
+    regs = [
+        topk.reg(f"reg{i}", WIDTH)
+        for i in range(k)
+    ]
+
+    # Continuously produce the sum of these registers. This could be a
+    # reduction tree, but for now it's just a reduction "stick."
+    with topk.continuous:
+        last_add = None
+        for i in range(1, k):
+            add = topk.add(f"sum{i}", WIDTH)
+            if last_add:
+                add.left = last_add.out
+            else:
+                add.left = regs[0].out
+            add.right = regs[i].out
+            last_add = add
+        topk.this().total = last_add.out
+
+    # Similarly, continuously compute the min and argmin of all our
+    # current values. There's a chance it would be better to wrap this
+    # up in a `comb group`, but it's not clear exactly where we would
+    # `with` it.
+    idx_width = k.bit_length()
+    with topk.continuous:
+        last_val = None
+        last_idx = None
+        for i in range(1, k):
+            left_val = last_val.out if last_val else regs[0].out
+            left_idx = last_idx.out if last_idx else 0
+
+            # Compare with the next register.
+            lt = topk.cell(f"lt{i}",
+                           ast.Stdlib().op("lt", WIDTH, signed=False))
+            lt.left = left_val
+            lt.right = regs[i].out
+
+            # Produce the resulting min and argmin.
+            val = topk.cell(f"val{i}",
+                            ast.Stdlib().op("wire", WIDTH, signed=False))
+            idx = topk.cell(f"idx{i}",
+                            ast.Stdlib().op("wire", idx_width, signed=False))
+            val.in_ = lt.out @ left_val
+            val.in_ = ~lt.out @ regs[i].out
+            idx.in_ = lt.out @ left_idx
+            idx.in_ = ~lt.out @ i
+
+            # Record the current wires for the next comparison.
+            last_val = val
+            last_idx = idx
+    min_val = last_val
+    min_idx = last_idx
+
+    # Check whether the input value is bigger than the smallest stored
+    # value.
+    gt = topk.cell("gt", ast.Stdlib().op("gt", WIDTH, signed=False))
+    with topk.comb_group("check") as check:
+        gt.left = topk.this().value
+        gt.right = min_val.out
+
+    # Replace the minimum value. Because we only have the index of the
+    # register we need, we need a bunch of conditional logic to write
+    # into the correct register.
+    with topk.group("upd") as upd:
+        for i in range(k):
+            const_i = const(idx_width, i)
+            regs[i].write_en = (min_idx.out == const_i) @ 1
+            regs[i].write_en = ~(min_idx.out == const_i) @ 0
+            regs[i].in_ = (min_idx.out == const_i) @ topk.this().value
+
+    # The control program.
+    topk.control += if_(gt.out, check, upd)
+
+    return topk
 
 
 if __name__ == '__main__':

--- a/1/accelgen.py
+++ b/1/accelgen.py
@@ -114,6 +114,7 @@ def build():
             accum_calories,
             incr,
         ]),
+        invoke(topk, in_value=accum.out),  # Count last elf.
         finish,
     ]
 

--- a/1/accelgen.py
+++ b/1/accelgen.py
@@ -209,7 +209,7 @@ def build_topk(prog: Builder, k: int):
         for i in range(k):
             const_i = const(idx_width, i)
             regs[i].write_en = (min_idx.out == const_i) @ 1
-            regs[i].write_en = ~(min_idx.out == const_i) @ 0
+            regs[i].write_en = (min_idx.out != const_i) @ 0
             regs[i].in_ = (min_idx.out == const_i) @ topk.this().value
             upd.done = (min_idx.out == const_i) @ regs[i].done
 


### PR DESCRIPTION
This was a fun extension to Day 1's "running maximum" logic that generalizes it to "running top-k" logic. It took a couple of tries to get my new `topk` generator correct, but if nothing else, I'm entertained by the solution (which involves an all-way parallel comparison to find the minimum value of the current `k` values).

I also fixed a bug in the first part! Namely, we never checked the _last_ elf (because my "elf separator" bitmask never becomes 1 after the final run of calorie counts). I thought it was pretty cool that the fix was just a one-line edit to the control program; I shudder to think how annoying this would have been to change in plain RTL.