### PR TITLE
Day 3, part 1

### DIFF
--- a/3/Makefile
+++ b/3/Makefile
@@ -1,0 +1,12 @@
+.PHONY: all
+all: sample
+
+accel.futil: accelgen.py
+	python3 $^ > $@
+
+%.json: %.txt
+	python3 convert.py < $^ > $@
+
+%: accel.futil %.json
+	fud e $< --to dat --through verilog -s verilog.data $*.json | \
+		jq .memories.answer[0]

--- a/3/Makefile
+++ b/3/Makefile
@@ -10,3 +10,10 @@ accel.futil: accelgen.py
 %: accel.futil %.json
 	fud e $< --to dat --through verilog -s verilog.data $*.json | \
 		jq .memories.answer[0]
+
+%-interp: accel.futil %.json
+	fud e $< --to interpreter-out -s verilog.data $*.json | \
+		jq .main.answer[0]
+
+%-debug: accel.futil %.json
+	fud e $< --to debugger -s verilog.data $*.json

--- a/3/README.md
+++ b/3/README.md
@@ -1,0 +1,20 @@
+Day 3: Rucksack Reorganization
+==============================
+
+Type one of these two to run on the sample input:
+
+    make sample
+    make sample-interp
+
+The latter uses Calyx's interpreter, Cider.
+I think it's interesting how much slower it is than the former, which uses Verilator.
+
+The data format for this puzzle was interestingly sparse for a hardware implementation.
+Instead of using a dense "marker" memory as I did for Day 1, this representation uses a memory full of rucksack sizes, which makes some things easier and some things harder.
+
+The code generator is made somewhat fiddly and long by the need for a loop nest; there are three loops total here.
+It makes me wonder if there wouldn't be some nice way to make it easier to construct standard `for` loops in Calyx's Python builder.
+
+The most hardwarey aspect of this puzzle was the "filter", i.e., the component that checks if we've seen a given item before.
+I used a value-indexed memory of 1-bit flags.
+It's basically the hardwarey reflection of a set of small values (and there are only 46 values in this domain).

--- a/3/accelgen.py
+++ b/3/accelgen.py
@@ -138,7 +138,8 @@ def build():
         init_rucksack,
         while_(rucksack_lt.out, check_rucksack, [
             # Reset the filter.
-            invoke(filter, in_clear=const(1, 1)),
+            invoke(filter, in_value=item.out, in_set=const(1, 1),
+                   in_clear=const(1, 1)),
 
             # First compartment.
             {init_items, reset_item},
@@ -184,7 +185,7 @@ def build_filter(prog, width):
     with filter.group("check_marker") as check_marker:
         markers.read_en = 1
         markers.addr0 = filter.this().value
-        present_reg.write_en = 1
+        present_reg.write_en = markers.read_done
         present_reg.in_ = markers.out
         check_marker.done = present_reg.done
 

--- a/3/accelgen.py
+++ b/3/accelgen.py
@@ -194,8 +194,8 @@ def build_filter(prog, width):
         filter.this().present = present_reg.out
 
     filter.control += if_(filter.this().set, None,
-                          check_marker,
-                          set_marker)
+                          set_marker,
+                          check_marker)
 
     return filter
 

--- a/3/accelgen.py
+++ b/3/accelgen.py
@@ -1,0 +1,72 @@
+import sys
+from calyx.builder import Builder, while_, invoke, const
+from calyx import py_ast as ast
+
+MAX_CONTENTS = 16384
+MAX_RUCKSACKS = 512
+ITEM_WIDTH = 6
+LENGTH_WIDTH = 8
+SCORE_WIDTH = 32
+
+RUCKSACK_IDX_WIDTH = MAX_RUCKSACKS.bit_length()
+
+
+def build_mem(comp, name, width, size, is_external=True, is_ref=False):
+    idx_width = size.bit_length()
+    comp.prog.import_("primitives/memories.futil")
+    inst = ast.CompInst("seq_mem_d1", [width, size, idx_width])
+    return comp.cell(name, inst, is_external=is_external, is_ref=is_ref)
+
+
+def build():
+    """Build the `main` component for AOC day 3.
+    """
+    prog = Builder()
+    main = prog.component("main")
+
+    # Inputs & outputs.
+    contents = build_mem(main, "contents", 2, MAX_CONTENTS)
+    lengths = build_mem(main, "lengths", 2, MAX_RUCKSACKS)
+    rucksacks = build_mem(main, "rucksacks", RUCKSACK_IDX_WIDTH, 1)
+    answer = build_mem(main, "answer", SCORE_WIDTH, 1)
+
+    # (Constant) register for rucksack loop limit.
+    rucksacks_reg = main.reg("rucksacks_reg", RUCKSACK_IDX_WIDTH)
+    with main.group("init_rucksack") as init_rucksack:
+        rucksacks.read_en = 1
+        rucksacks.addr0 = 0
+        rucksacks_reg.write_en = rucksacks.read_done
+        rucksacks_reg.in_ = rucksacks.out
+        init_rucksack.done = rucksacks_reg.done
+
+    # Increment for rucksack loop.
+    rucksack_idx = main.reg("rucksack_idx", RUCKSACK_IDX_WIDTH)
+    rucksack_add = main.add("rucksack_add", RUCKSACK_IDX_WIDTH)
+    with main.group("incr_rucksack") as incr_rucksack:
+        rucksack_add.left = rucksack_idx.out
+        rucksack_add.right = 1
+        rucksack_idx.write_en = 1
+        rucksack_idx.in_ = rucksack_add.out
+        incr_rucksack.done = rucksack_idx.done
+
+    # Exit check for rucksack loop.
+    rucksack_lt = main.cell(
+        "rucksack_lt",
+        ast.Stdlib().op("lt", RUCKSACK_IDX_WIDTH, signed=False),
+    )
+    with main.comb_group("check_rucksack") as check_rucksack:
+        rucksack_lt.left = rucksack_idx.out
+        rucksack_lt.right = rucksacks_reg.out
+
+    main.control += [
+        init_rucksack,
+        while_(rucksack_lt.out, check_rucksack, [
+            incr_rucksack,
+        ]),
+    ]
+
+    return prog.program
+
+
+if __name__ == '__main__':
+    build().emit()

--- a/3/accelgen.py
+++ b/3/accelgen.py
@@ -170,14 +170,13 @@ def build():
     main.control += [
         init_rucksack,
         while_(rucksack_lt.out, check_rucksack, [
-            save_next,
-
             # Reset the filter.
             invoke(filter, in_value=item.out, in_set=const(1, 1),
                    in_clear=const(1, 1)),
 
             # First compartment.
             {init_items, reset_item},
+            save_next,
             while_(item_lt.out, check_item, [
                 load_item,
                 invoke(filter, in_value=item.out, in_set=const(1, 1),

--- a/3/accelgen.py
+++ b/3/accelgen.py
@@ -127,6 +127,13 @@ def build():
         accum.in_ = accum_add.out
         accum_priority.done = accum.done
 
+    # Publish result back to interface memory.
+    with main.group("finish") as finish:
+        answer.write_en = 1
+        answer.addr0 = 0
+        answer.in_ = accum.out
+        finish.done = answer.write_done
+
     main.control += [
         init_rucksack,
         while_(rucksack_lt.out, check_rucksack, [
@@ -151,6 +158,7 @@ def build():
 
             incr_rucksack,
         ]),
+        finish,
     ]
 
     return prog.program

--- a/3/convert.py
+++ b/3/convert.py
@@ -1,0 +1,76 @@
+"""Generate memories for the rucksack contents.
+
+The idea is to use the priority value of each item (which unambiguously
+identifies the item in 6 bits). We record the *size* of one
+*compartment* in each rucksack (so this is a sparse encoding, unlike Day
+1).
+"""
+import sys
+import json
+
+MAX_CONTENTS = 16384
+MAX_RUCKSACKS = 512
+ITEM_WIDTH = 6
+LENGTH_WIDTH = 8
+SCORE_WIDTH = 32
+
+
+def char2pri(c):
+    return ord(c) - ord('a') + 1 if c > 'Z' else \
+        ord(c) - ord('A') + 27
+
+
+def convert(infile):
+    contents = []
+    lengths = []
+
+    for line in infile:
+        line = line.strip()
+        vals = [char2pri(c) for c in line]
+        contents += vals
+        lengths.append(len(vals) / 2)
+
+    assert len(contents) <= MAX_CONTENTS
+
+    return {
+        # Inputs.
+        "contents": {
+            "data": contents + [0] * (MAX_CONTENTS - len(contents)),
+            "format": {
+                "numeric_type": "bitnum",
+                "is_signed": False,
+                "width": ITEM_WIDTH,
+            }
+        },
+        "lengths": {
+            "data": lengths + [0] * (MAX_RUCKSACKS - len(lengths)),
+            "format": {
+                "numeric_type": "bitnum",
+                "is_signed": False,
+                "width": LENGTH_WIDTH,
+            }
+        },
+        "rucksacks": {
+            "data": [len(lengths)],
+            "format": {
+                "numeric_type": "bitnum",
+                "is_signed": False,
+                "width": MAX_RUCKSACKS.bit_length(),
+            },
+        },
+
+        # Output.
+        "answer": {
+            "data": [0],
+            "format": {
+                "numeric_type": "bitnum",
+                "is_signed": False,
+                "width": SCORE_WIDTH,
+            },
+        },
+    }
+
+
+if __name__ == "__main__":
+    json.dump(convert(sys.stdin), sys.stdout,
+              indent=2, sort_keys=True)

--- a/3/convert.py
+++ b/3/convert.py
@@ -28,7 +28,7 @@ def convert(infile):
         line = line.strip()
         vals = [char2pri(c) for c in line]
         contents += vals
-        lengths.append(len(vals) / 2)
+        lengths.append(len(vals) // 2)
 
     assert len(contents) <= MAX_CONTENTS
 

--- a/3/sample.txt
+++ b/3/sample.txt
@@ -1,0 +1,6 @@
+vJrwpWtwJgWrhcsFMMfFFhFp
+jqHRNqRjqzjGDLGLrsFMfFZSrLrFZsSL
+PmmdzqPrVvPwwTWBwg
+wMqvLMZHhHMvwLHjbvcjnnSBnvTQFn
+ttgJtRGJQctTZtZT
+CrZsJsPPZsGzwwsLwLmpwMDw


### PR DESCRIPTION
This one took me 3 hours, compared to the usual 2 for the other puzzles so far! Maybe because I am ill and can't quite think straight. And also maybe because I tried to get a little fancy with the "have I seen this before" data structure, which I ended up implementing as a 1-bit-per-value memory. It did work, though!

This was also my first time using Cider for these puzzles—it was _really_ helpful for a few nasty bugs I wrote! A++, would debug again. I do think it's interesting that the interpreter is pretty slow compared to Verilator; I wouldn't have expected this to be too chunky of a design:

```
$ time make full
python3 convert.py < full.txt > full.json
fud e accel.futil --to dat --through verilog -s verilog.data full.json | \
		jq .memories.answer[0]
8018
rm full.json
make full  3.81s user 0.83s system 111% cpu 4.159 total
$ time make full-interp
~/cu/research/aoc2022-calyx/3
python3 convert.py < full.txt > full.json
fud e accel.futil --to interpreter-out -s verilog.data full.json | \
		jq .main.answer[0]
8018
rm full.json
make full-interp  28.47s user 1.14s system 102% cpu 28.916 total
```

That's the end-to-end execution for both Verilator and Cider, including Verilator's compilation time. Verilator is about 7.5x faster. Who knew!