### PR TITLE
Day 3, part 2

### DIFF
--- a/3/Makefile
+++ b/3/Makefile
@@ -1,19 +1,33 @@
 .PHONY: all
 all: sample
 
-accel.futil: accelgen.py
-	python3 $^ > $@
+part1.futil: accelgen.py
+	python3 $^ 1 > $@
+
+part2.futil: accelgen.py
+	python3 $^ 3 > $@
 
 %.json: %.txt
 	python3 convert.py < $^ > $@
 
-%: accel.futil %.json
+%-part1: part1.futil %.json
 	fud e $< --to dat --through verilog -s verilog.data $*.json | \
 		jq .memories.answer[0]
 
-%-interp: accel.futil %.json
+%-part1-interp: part1.futil %.json
 	fud e $< --to interpreter-out -s verilog.data $*.json | \
 		jq .main.answer[0]
 
-%-debug: accel.futil %.json
+%-part1-debug: part1.futil %.json
+	fud e $< --to debugger -s verilog.data $*.json
+
+%-part2: part2.futil %.json
+	fud e $< --to dat --through verilog -s verilog.data $*.json | \
+		jq .memories.answer[0]
+
+%-part2-interp: part2.futil %.json
+	fud e $< --to interpreter-out -s verilog.data $*.json | \
+		jq .main.answer[0]
+
+%-part2-debug: part2.futil %.json
 	fud e $< --to debugger -s verilog.data $*.json

--- a/3/README.md
+++ b/3/README.md
@@ -6,16 +6,23 @@ Type one of these two to run on the sample input:
     make sample-part1
     make sample-part1-interp
 
-(The latter uses Calyx's interpreter, Cider.
+(The latter uses [Calyx's interpreter, Cider][cider].
 I think it's interesting how much slower it is than the former, which uses Verilator.)
 Or use `part2` instead to solve the version of the puzzle that looks at "teams" of 3 elves.
 
 The data format for this puzzle was interestingly sparse for a hardware implementation.
 Instead of using a dense "marker" memory as I did for Day 1, this representation uses a memory full of rucksack sizes, which makes some things easier and some things harder.
 
-The code generator is made somewhat fiddly and long by the need for a loop nest; there are three loops total here.
+The code generator is made somewhat fiddly and long by the need for a loop nest; there are three loops total here (for part 1).
 It makes me wonder if there wouldn't be some nice way to make it easier to construct standard `for` loops in Calyx's Python builder.
 
 The most hardwarey aspect of this puzzle was the "filter", i.e., the component that checks if we've seen a given item before.
 I used a value-indexed memory of 1-bit flags.
 It's basically the hardwarey reflection of a set of small values (and there are only 46 values in this domain).
+
+I went a little overboard generalizing this solution to cover both Part 1 and Part 2.
+It is, of course, possible to generate an accelerator for Part 2 that works with elf teams of *any* size, not just 3.
+We generate "unrolled" loops that cover each elf within a team---in other words, the looping happens in Python and we splat out nearly-identical control statements for every elf in the team.
+This makes the implementation of the generator fairly elaborate, and I think it also may reveal points where the code could be simplified with additional work on the Calyx builder.
+
+[cider]: https://docs.calyxir.org/interpreter.html

--- a/3/README.md
+++ b/3/README.md
@@ -3,11 +3,12 @@ Day 3: Rucksack Reorganization
 
 Type one of these two to run on the sample input:
 
-    make sample
-    make sample-interp
+    make sample-part1
+    make sample-part1-interp
 
-The latter uses Calyx's interpreter, Cider.
-I think it's interesting how much slower it is than the former, which uses Verilator.
+(The latter uses Calyx's interpreter, Cider.
+I think it's interesting how much slower it is than the former, which uses Verilator.)
+Or use `part2` instead to solve the version of the puzzle that looks at "teams" of 3 elves.
 
 The data format for this puzzle was interestingly sparse for a hardware implementation.
 Instead of using a dense "marker" memory as I did for Day 1, this representation uses a memory full of rucksack sizes, which makes some things easier and some things harder.

--- a/3/accelgen.py
+++ b/3/accelgen.py
@@ -239,12 +239,12 @@ def build(rucksacks_per_team=1):
                 populate_loop(filters[0]),
                 check_loop,
             ]
-        elif i == rucksacks_per_team - 1:
-            # *Check* the filter in the last rucksack.
-            team_control.append(check_loop)
-        else:
-            # *Populate* the filter for every other rucksack.
+        elif i < rucksacks_per_team - 1:
+            # *Populate* the filter for every rucksack but the last.
             team_control.append(populate_loop(filters[i]))
+        else:
+            # *Check* the filters in the last rucksack.
+            team_control.append(check_loop)
 
         # Advance to the next rucksack.
         team_control += [

--- a/3/accelgen.py
+++ b/3/accelgen.py
@@ -1,4 +1,5 @@
 from functools import reduce
+import sys
 from calyx.builder import Builder, while_, if_, const, invoke
 from calyx import py_ast as ast
 
@@ -377,4 +378,4 @@ def build_filter(prog, width):
 
 
 if __name__ == '__main__':
-    build().emit()
+    build(int(sys.argv[1])).emit()

--- a/3/accelgen.py
+++ b/3/accelgen.py
@@ -58,13 +58,22 @@ def build():
         rucksack_lt.left = rucksack_idx.out
         rucksack_lt.right = rucksacks_reg.out
 
-    # Register for the contents loop limit.
+    # Register for the contents loop limit. Divide the rucksack length
+    # by 2 to get the *compartment* length.
     items = main.reg("items", LENGTH_WIDTH)
+    rsh = main.cell(
+        "rsh",
+        ast.Stdlib().op("rsh", LENGTH_WIDTH, signed=False),
+    )
     with main.group("init_items") as init_items:
         lengths.read_en = 1
         lengths.addr0 = rucksack_idx.out
+
+        rsh.left = lengths.out
+        rsh.right = const(LENGTH_WIDTH, 1)  # Shift down 1 bit.
+
         items.write_en = lengths.read_done
-        items.in_ = lengths.out
+        items.in_ = rsh.out
         init_items.done = items.done
 
     # Reset the contents loop counter.

--- a/3/accelgen.py
+++ b/3/accelgen.py
@@ -195,13 +195,15 @@ def build(rucksacks_per_team=1):
     # Control fragment: a loop to *populate* a filter (i.e., mark
     # contents but don't check them).
     def populate_loop(filt):
-        reset_item,
-        return while_(item_lt.out, check_item, [
-            load_item,
-            invoke(filt, in_value=item.out, in_set=const(1, 1),
-                   in_clear=const(1, 0)),
-            {incr_item, incr_global_item},
-        ])
+        return [
+            reset_item,
+            while_(item_lt.out, check_item, [
+                load_item,
+                invoke(filt, in_value=item.out, in_set=const(1, 1),
+                       in_clear=const(1, 0)),
+                {incr_item, incr_global_item},
+            ]),
+        ]
 
     # Control fragment: a loop to *check* the filter, aborting early if
     # we find a collision.

--- a/3/convert.py
+++ b/3/convert.py
@@ -1,9 +1,8 @@
 """Generate memories for the rucksack contents.
 
 The idea is to use the priority value of each item (which unambiguously
-identifies the item in 6 bits). We record the *size* of one
-*compartment* in each rucksack (so this is a sparse encoding, unlike Day
-1).
+identifies the item in 6 bits). We record the *size* of one each
+rucksack (so this is a sparse encoding, unlike Day 1).
 """
 import sys
 import json
@@ -28,7 +27,7 @@ def convert(infile):
         line = line.strip()
         vals = [char2pri(c) for c in line]
         contents += vals
-        lengths.append(len(vals) // 2)
+        lengths.append(len(vals))
 
     assert len(contents) <= MAX_CONTENTS
 


### PR DESCRIPTION
This turned out to be quite a bit of work, but it was interesting! My "mistake" was generalizing the generator quite thoroughly so it could handle both Part 1 and Part 2 of the puzzle via parameterization—and handling arbitrary "elf team sizes" instead of just 3.

I think the interesting part is that I could have handled the latter dimension of generality either by generating "real" loops in hardware or by "unrolling" the loop at hardware-generation time. I picked unrolling. So there are loops in Python that generate nearly-identical hardware and control for each of the 3 elves in a given team. I think it would be interesting to think about how the generator could try flipping between these option, much like a traditional HLS language or Dahlia can switch between rolled and unrolled implementations for the same logically-equivalent loop. (Unlike HLS/Dahlia, however, my unrolled loops don't actually export any parallelism—which is necessary because of the sparse/data-dependent data format that feeds them.)

It's also worth noting that the generator code has gotten pretty big and hairy! It's feeling a little spaghettiful. I would like to come back to this and see if there's a way to compartmentalize the generator a bit, even if the final generated `main` component is still pretty chunky.